### PR TITLE
Force re-clustering when the user changes the distance threshold value

### DIFF
--- a/ObjectCluster/SoundEnginePlugin/KMeans.h
+++ b/ObjectCluster/SoundEnginePlugin/KMeans.h
@@ -223,6 +223,9 @@ public:
         float minDistanceThreshold = 10.f,
         float maxDistanceThreshold = 1000.f);
 
+
+    void reset();
+
     /**
      * @brief Sets the convergence tolerance.
      * @param newValue The new tolerance value.

--- a/ObjectCluster/SoundEnginePlugin/KMeans.h
+++ b/ObjectCluster/SoundEnginePlugin/KMeans.h
@@ -223,7 +223,9 @@ public:
         float minDistanceThreshold = 10.f,
         float maxDistanceThreshold = 1000.f);
 
-
+    /**
+     * @brief Resets the KMeans instance, clearing all clusters and centroids.
+     */
     void reset();
 
     /**

--- a/ObjectCluster/SoundEnginePlugin/Kmeans.cpp
+++ b/ObjectCluster/SoundEnginePlugin/Kmeans.cpp
@@ -342,6 +342,15 @@ KMeans::KMeans(float tolerance, float distanceThreshold, float minDistanceThresh
     seed = rd();
 }
 
+void KMeans::reset()
+{
+	centroids.clear();
+	labels.clear();
+	clusters.clear();
+	sse_values.clear();
+	unassignedPoints.clear();
+}
+
 void KMeans::setTolerance(float newValue) {
     m_tolerance = clamp(newValue, 0.001f, 1.0f);
 }

--- a/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.cpp
+++ b/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.cpp
@@ -117,7 +117,7 @@ void ObjectClusterFX::Execute(
     UpdateClusterPositions(inObjects);
 }
 
-void ObjectClusterFX::ForceRecluster()
+void ObjectClusterFX::ForceReclustering()
 {
 	m_clusters.clear();
 

--- a/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.cpp
+++ b/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.cpp
@@ -389,7 +389,7 @@ void ObjectClusterFX::FeedPositionsToKMeans(const AkAudioObjects& inObjects) {
     if (m_lastDistanceThreshold != m_pParams->RTPC.distanceThreshold) {
         m_kmeans->setDistanceThreshold(m_pParams->RTPC.distanceThreshold);
         m_lastDistanceThreshold = m_pParams->RTPC.distanceThreshold;
-        ForceRecluster();
+        ForceReclustering();
     }
 
     std::vector<ObjectPosition> objectPositions;
@@ -407,7 +407,7 @@ void ObjectClusterFX::FeedPositionsToKMeans(const AkAudioObjects& inObjects) {
         }
     }
 
-    // Perform clustering
+    // Perform clustering only if there are objects
     m_clusters.clear();
     if (!objectPositions.empty()) {
         m_kmeans->performClustering(objectPositions);

--- a/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.cpp
+++ b/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.cpp
@@ -117,6 +117,21 @@ void ObjectClusterFX::Execute(
     UpdateClusterPositions(inObjects);
 }
 
+void ObjectClusterFX::ForceRecluster()
+{
+	m_clusters.clear();
+
+    auto it = m_mapInObjsToOutObjs.Begin();
+    while (it != m_mapInObjsToOutObjs.End()) {
+        if ((*it).pUserData && (*it).pUserData->isClustered) {
+            (*it).pUserData->isClustered = false;
+        }
+        ++it;
+    }
+
+	m_kmeans->reset();
+}
+
 void ObjectClusterFX::PrepareAudioObjects(const AkAudioObjects& inObjects)
 {
     FeedPositionsToKMeans(inObjects);
@@ -369,21 +384,21 @@ void ObjectClusterFX::MixToCluster(const AkAudioObject* inObject, AkAudioBuffer*
     AKPLATFORM::AkMemCpy(pGeneratedObject->volumeMatrix, currentVolumes, uTransmixSize);
 }
 
-void ObjectClusterFX::FeedPositionsToKMeans(const AkAudioObjects& inObjects)
-{
-
+void ObjectClusterFX::FeedPositionsToKMeans(const AkAudioObjects& inObjects) {
+    // Check for threshold change before normal processing
     if (m_lastDistanceThreshold != m_pParams->RTPC.distanceThreshold) {
         m_kmeans->setDistanceThreshold(m_pParams->RTPC.distanceThreshold);
         m_lastDistanceThreshold = m_pParams->RTPC.distanceThreshold;
+        ForceRecluster();
     }
 
     std::vector<ObjectPosition> objectPositions;
     objectPositions.reserve(inObjects.uNumObjects);
 
+    // Check if objects should be clustered based on spatialization mode
     for (AkUInt32 i = 0; i < inObjects.uNumObjects; ++i) {
         AkAudioObject* inobj = inObjects.ppObjects[i];
 
-        // Check if this is either position-only or position+orientation
         bool shouldCluster = (inobj->positioning.behavioral.spatMode == AK_SpatializationMode_PositionOnly ||
             inobj->positioning.behavioral.spatMode == AK_SpatializationMode_PositionAndOrientation);
 
@@ -391,7 +406,8 @@ void ObjectClusterFX::FeedPositionsToKMeans(const AkAudioObjects& inObjects)
             objectPositions.push_back({ inobj->positioning.threeD.xform.Position(), inobj->key });
         }
     }
-    // Perform clustering only if there are objects
+
+    // Perform clustering
     m_clusters.clear();
     if (!objectPositions.empty()) {
         m_kmeans->performClustering(objectPositions);

--- a/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.h
+++ b/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.h
@@ -114,6 +114,9 @@ private:
     AK::IAkPluginMemAlloc* m_pAllocator;
     AK::IAkEffectPluginContext* m_pContext;
 
+    void ForceRecluster();
+	bool m_needsReclustering = false;
+
     /**
      * @brief Updates KMeans algorithm with input object positions
      * @param inObjects Input audio objects

--- a/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.h
+++ b/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.h
@@ -240,7 +240,6 @@ private:
 	std::vector<AkAudioObject*> m_tempObjects;
 
 	float m_lastDistanceThreshold = -1.0f;
-    bool m_needsReclustering = false;
 
 	/// Maps that hold KMeans clustering data
 	std::vector<std::pair<AkVector, std::vector<AkAudioObjectID>>> m_clusters;

--- a/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.h
+++ b/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.h
@@ -114,8 +114,10 @@ private:
     AK::IAkPluginMemAlloc* m_pAllocator;
     AK::IAkEffectPluginContext* m_pContext;
 
-    void ForceRecluster();
-	bool m_needsReclustering = false;
+    /**
+     * @brief Forces reclustering by clearing current clusters and resetting the KMeans algorithm.
+     */
+    void ForceReclustering();
 
     /**
      * @brief Updates KMeans algorithm with input object positions
@@ -238,6 +240,7 @@ private:
 	std::vector<AkAudioObject*> m_tempObjects;
 
 	float m_lastDistanceThreshold = -1.0f;
+    bool m_needsReclustering = false;
 
 	/// Maps that hold KMeans clustering data
 	std::vector<std::pair<AkVector, std::vector<AkAudioObjectID>>> m_clusters;


### PR DESCRIPTION
# Description
This PR introduces the ability to force a re-cluster of all audio objects when the distance threshold RTPC is changed in real-time.
Previously for a new threshold value to take effect, either the game-scene would have to change completely, or the plugin should be manually re-initialized to the bus. This means that the user would have to wait for all existing clusters to die so new ones are formed with the new assigned threshold value. Of course this is not optimal and can create the impression that the UI slider is not functional.

To solve this, we clear existing structures that hold cluster information and mark them as non-clustered, so they are forced to be re-clustered in the next frame. Keep in mind though, that the existing output objects will not be deleted with a slider change, as this would introduce potential crashes or sounds to disappear.

# Technical Details
- Introduced a `reset` method that resets the internal state of the KMeans algorithm.
- In the `ObjectClusterFX` we are checking for changes in the threshold RTPC, we force re-clustering.
- Introduced the method `ForceReclustering()` which clears the member variable `m_clusters` the `AkMixerInputMap` structure (which is the most important for the re-clustering to happen) and finally `reset()` the internal state of KMeans.

# Testing:
To test these changes, I recommend the following steps:

- Remove the plugin from everywhere instantiated so it doesn't interfere.
- Attach the plugin only on the Master bus with the minimum threshold of 1.
- Create a fight scene with multiple spatial audio objects
- As you Monitor the system audio object consumption, increase the slider to its max value.

You should see the audio object consumption being reduced drastically.


The GIF below shows a scene with 40 spawned enemies, initially the audio object consumption is 70-80 objects, when the threshold increases it drops to 38-40 depending on the events, which is the expected value.


![Wwise_sEAtbhhtJC](https://github.com/user-attachments/assets/bf18c1c7-dba8-4d76-bad6-4fd6734021fe)

and on another example with 20 enemies:

https://github.com/user-attachments/assets/c12110fe-7d6c-437d-bfc3-82b2dee9e907


