### PR TITLE
Fix crash for Wwise 2023 SDK - Remove unnecessary copying of metadata during processing of unclustered objects

### DIFF
--- a/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.cpp
+++ b/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.cpp
@@ -338,9 +338,13 @@ void ObjectClusterFX::ProcessUnclustered(
     AkAudioObject* outObj,
     AkAudioBuffer* outBuf) {
 
+    if (outObj == nullptr || inBuf == nullptr || outBuf == nullptr) {
+        return;
+    }
+
     m_utilities->CopyBuffer(inBuf, outBuf);
     outObj->positioning.threeD.xform.SetPosition(inObj->positioning.threeD.xform.Position());
-    outObj->arCustomMetadata.Copy(inObj->arCustomMetadata);
+
     outBuf->eState = inBuf->eState;
     outBuf->uValidFrames = inBuf->uValidFrames;
     outObj->SetName(m_pAllocator, "Not clustered");

--- a/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.h
+++ b/ObjectCluster/SoundEnginePlugin/ObjectClusterFX.h
@@ -40,6 +40,7 @@ trademarks of CCP ehf.
 #include <unordered_map>
 #include "KMeans.h"
 #include "Utilities.h"
+#include <memory>
 
 /**
  * @struct GeneratedObject


### PR DESCRIPTION
## Description
After upgrading to the Wwise 2023 SDK we noticed a crash related to changes in `AkArray.h`. This caused a crash during the copying of metadata for objects in an unclustered state, that didn't occur in prior verisons.

## Technical Details:
The copying was removed as it was unnecessary regardless and some checks were placed for the in/out buffer states.

## Testing:
This was tested with Wwise 2023 Authoring tool, and we confirmed that the crash was no longer occurring, and with our game client as well. 