### PR TITLE
fix(cluster): drop bogus AkAlloca and reset per-frame state

### DIFF
--- a/ObjectCluster/SoundEnginePlugin/Kmeans.cpp
+++ b/ObjectCluster/SoundEnginePlugin/Kmeans.cpp
@@ -351,7 +351,8 @@ void KMeans::setDistanceThreshold(float newValue) {
 }
 
 void KMeans::performClustering(const std::vector<ObjectPosition>& objects, unsigned int max_iterations) {
-    labels.resize(objects.size(), -1);
+    sse_values.clear();
+    labels.assign(objects.size(), -1);
     maxClusters = determineMaxClusters(objects.size());
     initializeCentroids(objects);
 

--- a/ObjectCluster/SoundEnginePlugin/Utilities.cpp
+++ b/ObjectCluster/SoundEnginePlugin/Utilities.cpp
@@ -57,8 +57,8 @@ AkAudioObjectID Utilities::CreateOutputObject(const AkAudioObject* inobj, const 
 {
     AkAudioObjectID outputObjKey = AK_INVALID_AUDIO_OBJECT_ID;
     AkUInt32 numObjsOut = 1;
-    // Allocate space for a new output object
-    AkAudioObject* newObject = (AkAudioObject*)AkAlloca(sizeof(AkAudioObject*));
+    // CreateOutputObjects allocates the object and fills this slot
+    AkAudioObject* newObject = nullptr;
     AkAudioObjects outputObjects;
     outputObjects.uNumObjects = numObjsOut;
     outputObjects.ppObjectBuffers = nullptr;


### PR DESCRIPTION
## Summary
Fixes a stack-corruption risk and an unbounded per-frame memory growth in
the real-time clustering path.

## Problem
1. `CreateOutputObject` did `AkAlloca(sizeof(AkAudioObject*))` and treated
   it as an `AkAudioObject`. `CreateOutputObjects` only needs a single
   pointer slot it fills itself, so the alloca was wrong and a
   stack-corruption hazard.
2. `performClustering` never cleared `sse_values`, which is `push_back`'d
   every iteration of every audio frame — unbounded memory growth plus a
   convergence test indexed by `iter` against stale data.

## Fix
Use a null pointer slot (matching the existing pattern in
`ObjectClusterFX.cpp`). Clear `sse_values` and `assign` labels at the start
of `performClustering` so each run starts clean.

## Type
Stability (stack corruption) + real-time correctness/memory (Critical).

## Testing
Manual review; output-object creation now follows the Wwise SDK contract;
clustering state is per-call.